### PR TITLE
[Feat] 종목명 검색 기능 구현

### DIFF
--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.Designer.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.Designer.cs
@@ -45,6 +45,8 @@ namespace trading_bot_prototype
             this.txtPassword = new System.Windows.Forms.TextBox();
             this.txtStockCode = new System.Windows.Forms.TextBox();
             this.btnRequestStockInfo = new System.Windows.Forms.Button();
+            this.txtStockName = new System.Windows.Forms.TextBox();
+            this.lstStockCandidates = new System.Windows.Forms.ListBox();
             ((System.ComponentModel.ISupportInitialize)(this.axKHOpenAPI1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -181,11 +183,29 @@ namespace trading_bot_prototype
             this.btnRequestStockInfo.Text = "종목 조회";
             this.btnRequestStockInfo.UseVisualStyleBackColor = true;
             // 
+            // txtStockName
+            // 
+            this.txtStockName.Location = new System.Drawing.Point(22, 222);
+            this.txtStockName.Name = "txtStockName";
+            this.txtStockName.Size = new System.Drawing.Size(100, 21);
+            this.txtStockName.TabIndex = 15;
+            // 
+            // lstStockCandidates
+            // 
+            this.lstStockCandidates.FormattingEnabled = true;
+            this.lstStockCandidates.ItemHeight = 12;
+            this.lstStockCandidates.Location = new System.Drawing.Point(129, 222);
+            this.lstStockCandidates.Name = "lstStockCandidates";
+            this.lstStockCandidates.Size = new System.Drawing.Size(120, 88);
+            this.lstStockCandidates.TabIndex = 16;
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.lstStockCandidates);
+            this.Controls.Add(this.txtStockName);
             this.Controls.Add(this.btnRequestStockInfo);
             this.Controls.Add(this.txtStockCode);
             this.Controls.Add(this.txtPassword);
@@ -226,6 +246,8 @@ namespace trading_bot_prototype
         private System.Windows.Forms.TextBox txtPassword;
         private System.Windows.Forms.TextBox txtStockCode;
         private System.Windows.Forms.Button btnRequestStockInfo;
+        private System.Windows.Forms.TextBox txtStockName;
+        private System.Windows.Forms.ListBox lstStockCandidates;
     }
 }
 

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
+using System.Linq;
 
 namespace trading_bot_prototype
 {
     public partial class Form1 : Form
     {
+        private Dictionary<string, string> nameToCode = new Dictionary<string, string>();
+
         public Form1()
         {
             InitializeComponent();
@@ -179,6 +183,26 @@ namespace trading_bot_prototype
                 return raw;
 
             return val.ToString("N0");
+        }
+
+
+        private void LoadStockNameDictionary()
+        {
+            nameToCode.Clear();
+
+            var kospi = axKHOpenAPI1.GetCodeListByMarket("0").Split(';');
+            var kosdaq = axKHOpenAPI1.GetCodeListByMarket("10").Split(';');
+
+            foreach (var code in kospi.Concat(kosdaq))
+            {
+                if (string.IsNullOrWhiteSpace(code)) continue;
+                string name = axKHOpenAPI1.GetMasterCodeName(code).Trim();
+
+                if (!nameToCode.ContainsKey(name))
+                    nameToCode[name] = code;
+            }
+
+            WriteLog($"종목명 매핑 완료 - 총 {nameToCode.Count}건");
         }
     }
 }

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -54,6 +54,8 @@ namespace trading_bot_prototype
                         WriteLog($"- {acc}");
                     }
                     WriteLog($"서버 종류: {(serverType == "1" ? "모의투자" : "실서버")}");
+
+                    LoadStockNameDictionary();
                 }
                 else
                 {

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -177,6 +177,16 @@ namespace trading_bot_prototype
 
                 lstStockCandidates.Items.AddRange(filtered.ToArray());
             };
+
+            lstStockCandidates.SelectedIndexChanged += (s, e) =>
+            {
+                if (lstStockCandidates.SelectedItem == null) return;
+
+                string selected = lstStockCandidates.SelectedItem.ToString();
+                // "삼성전자우 (005935)" → "005935" 추출
+                string code = selected.Split('(', ')')[1];
+                txtStockCode.Text = code;
+            };
         }
 
         private void WriteLog(string message)

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -161,6 +161,22 @@ namespace trading_bot_prototype
                 else
                     WriteLog($"종목 [{code}] 정보 조회 요청 실패");
             };
+
+            txtStockName.TextChanged += (s, e) =>
+            {
+                string keyword = txtStockName.Text.Trim();
+                lstStockCandidates.Items.Clear();
+
+                if (keyword.Length < 1) return;
+
+                var filtered = nameToCode
+                    .Where(kv => kv.Key.Contains(keyword))
+                    .OrderBy(kv => kv.Key)
+                    .Select(kv => $"{kv.Key} ({kv.Value})")
+                    .ToList();
+
+                lstStockCandidates.Items.AddRange(filtered.ToArray());
+            };
         }
 
         private void WriteLog(string message)


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 사용자가 종목명을 입력하면 유사 종목명을 실시간으로 리스트업하는 기능 추가
- 리스트에서 종목명을 선택하면 종목코드가 자동으로 입력되어 종목 조회 요청과 연동 가능
- 키움 API를 통해 전체 종목명-종목코드 매핑 딕셔너리를 로딩하는 기능 구현

# 제안 사항
- `txtStockName`(TextBox), `lstStockCandidates`(ListBox) UI 컴포넌트 추가  
  > 사용자가 종목명을 입력하고, 유사 종목 목록에서 선택 가능하도록 구성

- `LoadStockNameDictionary()` 함수 구현 및 로그인 성공 시 호출  
  > `GetCodeListByMarket("0")`, `"10"`으로 코스피/코스닥 전체 종목코드 수집 후  
  > `GetMasterCodeName()`으로 종목명과 매핑하여 `Dictionary<string 종목명, string 종목코드>` 구성

- `txtStockName.TextChanged` 이벤트에서 종목명 필터링 및 ListBox에 출력  
  > `Contains()` 기반의 실시간 유사 종목 검색 기능 구현  
  > 대소문자 구분 제거를 위해 `ToLower()` 비교 처리

- `lstStockCandidates.SelectedIndexChanged` 이벤트에서 종목 선택 시 코드 추출  
  > 선택된 종목의 종목코드를 `txtStockCode`에 자동 세팅 → 기존 조회 로직과 연결

- 종목명 검색 결과가 없거나 딕셔너리가 비어있을 때를 대비해 초기화 시점 제어

# 기타 개선
- `using System.Linq` 추가하여 `Concat`, `Where`, `OrderBy`, `Select` 등의 LINQ 메서드 활용
- 종목명 딕셔너리 초기화 완료 시 `WriteLog("종목명 매핑 완료 - 총 N건")`으로 사용자 피드백 제공



# (선택)스크린샷
![image](https://github.com/user-attachments/assets/c2e0c3c9-2854-4326-b58a-0d2cc6326949)



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
