### PR TITLE
[Refactor] KiwoomApiWrapper 클래스 분리

### DIFF
--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -61,8 +61,6 @@ namespace trading_bot_prototype
                         _logger.Log($"- {acc}");
                     }
                     _logger.Log($"서버 종류: {(serverType == "1" ? "모의투자" : "실서버")}");
-
-                    LoadStockNameDictionary();
                 }
                 else
                 {
@@ -82,7 +80,7 @@ namespace trading_bot_prototype
             // 연결 확인 버튼 클릭 이벤트 핸들러
             btnCheckConnect.Click += (s, e) =>
             {
-                if (axKHOpenAPI1.GetConnectState() == 0)
+                if (_api.GetConnectState() == 0)
                     _logger.Log("Open API 연결되어 있지 않습니다.");
                 else
                     _logger.Log("Open API 연결 중입니다.");

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -108,7 +108,7 @@ namespace trading_bot_prototype
                 axKHOpenAPI1.SetInputValue("비밀번호입력매체구분", "00"); // PC
                 axKHOpenAPI1.SetInputValue("조회구분", "1"); // 합산
 
-                int result = axKHOpenAPI1.CommRqData("예수금요청", "opw00001", 0, "9000");
+                int result = _api.RequestBalance(account, password);
 
                 if (result == 0)
                     _logger.Log("예수금 조회 요청 성공");

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -161,7 +161,7 @@ namespace trading_bot_prototype
                 }
 
                 axKHOpenAPI1.SetInputValue("종목코드", code);
-                int result = axKHOpenAPI1.CommRqData("종목정보요청", "opt10001", 0, "9100");
+                int result = _api.RequestStockInfo(code);
 
                 if (result == 0)
                     _logger.Log($"종목 [{code}] 정보 조회 요청 성공");

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -7,14 +7,16 @@ namespace trading_bot_prototype
 {
     public partial class Form1 : Form
     {
-        private Dictionary<string, string> nameToCode = new Dictionary<string, string>();
-        private Logger _logger;
+        private readonly Dictionary<string, string> nameToCode = new Dictionary<string, string>();
+        private readonly Logger _logger;
+        private readonly PriceFormatter _formatter;
 
         public Form1()
         {
             InitializeComponent();
             this.Load += new EventHandler(this.Form1_Load);
             _logger = new Logger(rtxtLog);
+            _formatter = new PriceFormatter();
         }
 
         private void Form1_Load(object sender, EventArgs e)
@@ -118,7 +120,7 @@ namespace trading_bot_prototype
                 if (e.sRQName == "예수금요청")
                 {
                     string cashRaw = axKHOpenAPI1.GetCommData(e.sTrCode, e.sRQName, 0, "예수금");
-                    string cashFormatted = FormatPrice(cashRaw);
+                    string cashFormatted = _formatter.Format(cashRaw);
 
                     _logger.Log($"현재 매수 가능 예수금: {cashFormatted}원");
                     lblBalance.Text = $"예수금: {cashFormatted}원";
@@ -138,11 +140,11 @@ namespace trading_bot_prototype
                     _logger.Log($"[종목 정보]");
                     _logger.Log($"코드: {code}");
                     _logger.Log($"이름: {name}");
-                    _logger.Log($"시가: {FormatPrice(open)}");
-                    _logger.Log($"고가: {FormatPrice(high)}");
-                    _logger.Log($"저가: {FormatPrice(low)}");
-                    _logger.Log($"상한가: {FormatPrice(upper)}");
-                    _logger.Log($"기준가: {FormatPrice(basePrice)}");
+                    _logger.Log($"시가: {_formatter.Format(open)}");
+                    _logger.Log($"고가: {_formatter.Format(high)}");
+                    _logger.Log($"저가: {_formatter.Format(low)}");
+                    _logger.Log($"상한가: {_formatter.Format(upper)}");
+                    _logger.Log($"기준가: {_formatter.Format(basePrice)}");
                     _logger.Log($"유통비율: {floatRate}");
                 }
             };
@@ -192,22 +194,6 @@ namespace trading_bot_prototype
                 txtStockCode.Text = code;
             };
         }
-
-        private string FormatPrice(string raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw))
-                return "0";
-
-            raw = raw.Trim().TrimStart('0');
-            if (string.IsNullOrEmpty(raw))
-                raw = "0";
-
-            if (!long.TryParse(raw, out long val))
-                return raw;
-
-            return val.ToString("N0");
-        }
-
 
         private void LoadStockNameDictionary()
         {

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/KiwoomApiWrapper.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/KiwoomApiWrapper.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using AxKHOpenAPILib;
+
+namespace trading_bot_prototype
+{
+    /// <summary>
+    /// 키움증권 OpenAPI를 감싸는 래퍼 클래스
+    /// </summary>
+    public class KiwoomApiWrapper
+    {
+        private readonly AxKHOpenAPI _api;
+
+        public KiwoomApiWrapper(AxKHOpenAPI api)
+        {
+            _api = api;
+        }
+
+        public string GetUserId() => _api.GetLoginInfo("USER_ID");
+        public string GetUserName() => _api.GetLoginInfo("USER_NAME");
+        public string GetServerType() => _api.GetLoginInfo("GetServerGubun");
+
+        public string[] GetAccountList()
+        {
+            var raw = _api.GetLoginInfo("ACCNO");
+            return raw.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public Dictionary<string, string> GetStockCodeNameMap()
+        {
+            var result = new Dictionary<string, string>();
+            foreach (var market in new[] { "0", "10" }) // 코스피 + 코스닥
+            {
+                var codes = _api.GetCodeListByMarket(market).Split(';');
+                foreach (var code in codes)
+                {
+                    if (string.IsNullOrWhiteSpace(code)) continue;
+                    var name = _api.GetMasterCodeName(code).Trim();
+                    if (!result.ContainsKey(name))
+                        result[name] = code;
+                }
+            }
+            return result;
+        }
+
+        public int RequestBalance(string account, string password)
+        {
+            _api.SetInputValue("계좌번호", account);
+            _api.SetInputValue("비밀번호", password);
+            _api.SetInputValue("비밀번호입력매체구분", "00"); // PC
+            _api.SetInputValue("조회구분", "1"); // 합산
+            return _api.CommRqData("예수금요청", "opw00001", 0, "9000");
+        }
+
+        public int RequestStockInfo(string code)
+        {
+            _api.SetInputValue("종목코드", code);
+            return _api.CommRqData("종목정보요청", "opt10001", 0, "9100");
+        }
+
+        public int CommConnect() => _api.CommConnect();
+        public int GetConnectState() => _api.GetConnectState();
+    }
+}

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype.csproj
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype.csproj
@@ -53,6 +53,7 @@
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
     <Compile Include="Logger.cs" />
+    <Compile Include="PriceFormatter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Form1.resx">


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- `Form1` 클래스에서 직접 호출하고 있던 `axKHOpenAPI1` 메서드 접근을 제거하고, 별도 `KiwoomApiWrapper` 클래스로 분리
- 로그인 정보, 계좌 목록, 종목 코드-이름 맵, 예수금 조회, 종목 정보 요청 등을 래핑하여 호출
- `Form1`은 `_api.GetUserId()`, `_api.RequestBalance(...)` 등 래퍼 인스턴스를 통해 API를 사용

# 제안 사항
- `KiwoomApiWrapper` 클래스 생성
  > `AxKHOpenAPI` 컴포넌트를 주입받아 API 호출을 캡슐화  
  > `GetLoginInfo`, `GetAccountList`, `GetStockCodeNameMap`, `RequestBalance`, `RequestStockInfo` 메서드 정의

- `Form1` 내부에서 `axKHOpenAPI1` 직접 호출 제거
  > 대신 `_api` 인스턴스를 통해 필요한 기능 호출

- 종목명 매핑 로직도 `LoadStockNameDictionary()` 메서드 제거 후 `_api.GetStockCodeNameMap()`으로 대체
  > `Dictionary<string, string>` 형태로 바로 대입

# 기대 효과
- `Form1`은 UI 이벤트 처리에 집중하고, API 호출은 전담 클래스에서 관리하도록 구조 개선
- OpenAPI 호출이 한 곳으로 집중되어 추후 유지보수 및 확장 용이
- 향후 타 증권사 API 대응, 테스트용 Mock 교체 등에도 유연하게 대처 가능
- SOLID 원칙의 단일 책임(SRP), 의존성 역전(DIP) 구조 강화



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
