### PR TITLE
[Fix] 종목 검색 시 키워드가 포함된 종목명이 검색되지 않는 문제 픽스

### DIFF
--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/Form1.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace trading_bot_prototype
 {
     public partial class Form1 : Form
     {
-        private readonly Dictionary<string, string> nameToCode;
+        private readonly Dictionary<string, string> nameToCode = new Dictionary<string, string>();
         private readonly Logger _logger;
         private readonly PriceFormatter _formatter;
         private readonly KiwoomApiWrapper _api;
@@ -33,8 +32,6 @@ namespace trading_bot_prototype
                     LblServerType = lblServerType,
                     LblBalance = lblBalance
                 });
-
-            nameToCode = _api.GetStockCodeNameMap();
 
             _stock = new StockService(
                 _api,
@@ -65,6 +62,8 @@ namespace trading_bot_prototype
                 {
                     _logger.Log("로그인 성공");
                     _account.HandleLoginSuccess();
+                    _api.PopulateStockCodeNameMap(nameToCode);
+                    _logger.Log($"종목명 사전 로딩 완료 - 총 {nameToCode.Count}건");
                 }
                 else
                 {

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/KiwoomApiWrapper.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/KiwoomApiWrapper.cs
@@ -26,9 +26,11 @@ namespace trading_bot_prototype
             return raw.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public Dictionary<string, string> GetStockCodeNameMap()
+        /// <summary>
+        /// 주어진 딕셔너리에 종목명-코드 매핑 정보를 채워넣는다.
+        /// </summary>
+        public void PopulateStockCodeNameMap(Dictionary<string, string> map)
         {
-            var result = new Dictionary<string, string>();
             foreach (var market in new[] { "0", "10" }) // 코스피 + 코스닥
             {
                 var codes = _api.GetCodeListByMarket(market).Split(';');
@@ -36,11 +38,10 @@ namespace trading_bot_prototype
                 {
                     if (string.IsNullOrWhiteSpace(code)) continue;
                     var name = _api.GetMasterCodeName(code).Trim();
-                    if (!result.ContainsKey(name))
-                        result[name] = code;
+                    if (!map.ContainsKey(name))
+                        map[name] = code;
                 }
             }
-            return result;
         }
 
         public int RequestBalance(string account, string password)

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/StockService.cs
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/StockService.cs
@@ -40,13 +40,13 @@ namespace trading_bot_prototype
         /// </summary>
         public void OnStockNameChanged()
         {
-            string keyword = _txtStockName.Text.Trim();
+            string keyword = _txtStockName.Text.Trim().ToLowerInvariant();
             _lstStockCandidates.Items.Clear();
 
-            if (keyword.Length < 1) return;
+            if (string.IsNullOrEmpty(keyword)) return;
 
             var filtered = _nameToCode
-                .Where(kv => kv.Key.Contains(keyword))
+                .Where(kv => kv.Key.ToLowerInvariant().Contains(keyword))
                 .OrderBy(kv => kv.Key)
                 .Select(kv => $"{kv.Key} ({kv.Value})")
                 .ToList();

--- a/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype.csproj
+++ b/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype/trading-bot-prototype.csproj
@@ -59,6 +59,8 @@
     <Compile Include="PriceFormatter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StockService.cs" />
+    <Compile Include="StockUIContext.cs" />
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

## 📌 변경된 기능

- 종목 검색 입력 시 자동완성 후보가 나오지 않던 문제 해결
- 종목명-종목코드 매핑을 로그인 성공 이후에 불러오도록 변경
- 종목 코드 맵 로딩 메서드를 `GetStockCodeNameMap()` → `PopulateStockCodeNameMap(Dictionary<string, string>)`으로 리팩토링
- 종목 검색 필터링 시 대소문자 무시하도록 개선

---

## ✅ 변경 이유

- 기존에는 `Form1()` 생성자에서 `_api.GetStockCodeNameMap()`을 호출하면서 로그인 이전에 API를 호출하게 되어 오류 발생
- 종목 리스트는 로그인 이후에만 정상적으로 조회 가능하기 때문에 초기화 타이밍이 꼬이는 문제 존재
- 함수명도 `Get*`이라는 조회 성격에서 `Populate*`이라는 데이터 설정 성격으로 명확히 변경

---

## 🛠️ 구현 상세

- `KiwoomApiWrapper`에 `PopulateStockCodeNameMap(Dictionary<string, string>)` 메서드 추가  
  → 외부에서 딕셔너리를 만들어 넘기면 내부에서 데이터 채워줌
- `Form1.cs`의 로그인 성공 이벤트(`OnEventConnect`) 내부에서:
  - `nameToCode.Clear();`
  - `_api.PopulateStockCodeNameMap(nameToCode);`
  - `_logger.Log(...)` 호출로 완료 로그 출력
- `StockService.OnStockNameChanged()` 내에서 `ToLowerInvariant()` 기반 비교로 대소문자 구분 제거


# (선택)스크린샷
![image](https://github.com/user-attachments/assets/9ff24d4d-d28a-4b11-bc54-4f51b7aa0a48)


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
